### PR TITLE
Workaround: oAuth fails with empty `scope` parameter

### DIFF
--- a/src/Iamstuartwilson/StravaApi.php
+++ b/src/Iamstuartwilson/StravaApi.php
@@ -134,9 +134,12 @@
                 'redirect_uri'    => $redirect,
                 'response_type'   => 'code',
                 'approval_prompt' => $approvalPrompt,
-                'scope'           => $scope,
                 'state'           => $state,
             );
+
+            if (! is_null($scope)) {
+                $parameters['scope'] = $scope;
+            }
 
             return $this->parseGet(
                 $this->authUrl . 'authorize',


### PR DESCRIPTION
Strava responds with 400 Bad Request when an empty
`scope` parameter is sent in the first authorization
request.

A request to the following URL will fail:

    https://www.strava.com/oauth/authorize?client_id=XXXXX&redirect_uri=YYYYY&response_type=code&scope=&approval_prompt=auto&state=default

Error message:

    {"message":"Bad Request","errors":[{"resource":"Authorize","field":"scope","code":"invalid"}]}

The authorization flow works as intended if the
`scope` parameter is removed from the query string:

    https://www.strava.com/oauth/authorize?client_id=XXXXX&redirect_uri=YYYYY&response_type=code&approval_prompt=auto&state=default

Interesting: the API didn’t show this behaviour
some months ago.

I’ve made the according changes to the StravaApi
class - the scope parameter is only sent with
the oAuth request if it was explicitly set.