### PR TITLE
PHP 7 compatibility and test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.idea/
+/composer.lock
 
 /vendor/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
 
-php: 5.5
+php:
+  - 5.5
+  - 7.0
 
 install:
   - travis_retry composer install --no-interaction

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,3 @@ php:
 
 install:
   - travis_retry composer install --no-interaction
-
-script: exit 0

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,10 @@
         }
     ],
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "php": "~5.5"
+        "php": ">=5.5"
     },
     "autoload": {
         "psr-0" : {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,10 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "~5.5"
         "php": ">=5.5"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.8"
     },
     "autoload": {
         "psr-0" : {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="strava-api">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/StravaApiTest.php
+++ b/tests/StravaApiTest.php
@@ -1,0 +1,46 @@
+<?php
+
+class StravaApiTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Iamstuartwilson\StravaApi
+     */
+    private $stravaApi;
+
+    public function setUp()
+    {
+        $this->stravaApi = new \Iamstuartwilson\StravaApi(999, '_SECRET_');
+    }
+
+    public function tearDown()
+    {
+        unset($this->stravaApi);
+    }
+
+    public function testIfAuthenticationUrlWorksAsExpected()
+    {
+        $expected = 'https://www.strava.com/oauth/authorize'
+            . '?client_id=999'
+            . '&redirect_uri=' . urlencode('https://example.org/')
+            . '&response_type=code'
+            . '&approval_prompt=auto';
+
+        $url = $this->stravaApi->authenticationUrl('https://example.org/', 'auto', null, null);
+
+        $this->assertEquals($expected, $url);
+    }
+
+    public function testIfAuthenticationUrlWithScopeWorksAsExpected()
+    {
+        $expected = 'https://www.strava.com/oauth/authorize'
+            . '?client_id=999'
+            . '&redirect_uri=' . urlencode('https://example.org/')
+            . '&response_type=code'
+            . '&approval_prompt=auto'
+            . '&scope=read';
+
+        $url = $this->stravaApi->authenticationUrl('https://example.org/', 'auto', 'read', null);
+
+        $this->assertEquals($expected, $url);
+    }
+}


### PR DESCRIPTION
Hi Stuart,

I've changed the `composer.json` file so that the the library can be used for PHP 7 projects.

Additionally, I added two test cases for the authorization URL generation.

Happy new year!

Marcus