### PR TITLE
Fix namespace declaration for `Exception`

### DIFF
--- a/src/Iamstuartwilson/StravaApi.php
+++ b/src/Iamstuartwilson/StravaApi.php
@@ -109,7 +109,7 @@
             curl_close($curl);
 
             if (! $response) {
-                throw new Exception($error);
+                throw new \Exception($error);
             } else {
                 return $this->parseResponse($response);
             }


### PR DESCRIPTION
Wenn a API HTTP request fails, an exception is thrown. Currently the `Exception` class cannot be found because its namespace is not declared correctly. This commit fixes that error.

This commit is a fix for issue #11 