### PR TITLE
Enable client users to specify an absolute URL for webhooks etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,9 @@ Simple PHP class to interact with Strava's V3 API.
 VERSION BUMP
 -------
 
-Latest version **1.2.2**
+Latest version **1.3.0**
 
-**Updates include:**
-
-- Possibility to access the HTTP response headers
-- PHP 7 compatibility
-- Basic PHPUnit test cases for Auth URL generation
+- Adds possibility to use absolute URL for an endpoint to work with [new webhook functionality](http://strava.github.io/api/partner/v3/events/)
 
 Overview
 ------------
@@ -44,7 +40,7 @@ Add `iamstuartwilson/strava` to your `composer.json`:
 ``` json
 {
     "require" : {
-        "iamstuartwilson/strava" : "~1.2"
+        "iamstuartwilson/strava" : "~1.3"
     }
 }
 ```
@@ -122,3 +118,16 @@ $api->delete('activities/:id');
 **1**. The account you register your app will give you an access token, so you can skip this step if you're just testing endpoints/methods.
 
 **2**. These actions will need the **scope** set to *write* when authenticating a user
+
+---
+
+Historic Releases
+---
+
+Previous version **1.2.2**
+
+**Updates include:**
+
+- Possibility to access the HTTP response headers
+- PHP 7 compatibility
+- Basic PHPUnit test cases for Auth URL generation

--- a/src/Iamstuartwilson/StravaApi.php
+++ b/src/Iamstuartwilson/StravaApi.php
@@ -254,7 +254,7 @@
         public function get($request, $parameters = array())
         {
             $parameters = $this->generateParameters($parameters);
-            $requestUrl = $this->parseGet($this->apiUrl . $request, $parameters);
+            $requestUrl = $this->parseGet($this->getAbsoluteUrl($request), $parameters);
 
             return $this->request($requestUrl);
         }
@@ -272,7 +272,7 @@
         public function put($request, $parameters = array())
         {
             return $this->request(
-                $this->apiUrl . $request,
+                $this->getAbsoluteUrl($request),
                 $this->generateParameters($parameters),
                 'PUT'
             );
@@ -290,9 +290,8 @@
          */
         public function post($request, $parameters = array())
         {
-
             return $this->request(
-                $this->apiUrl . $request,
+                $this->getAbsoluteUrl($request),
                 $this->generateParameters($parameters)
             );
         }
@@ -310,7 +309,7 @@
         public function delete($request, $parameters = array())
         {
             return $this->request(
-                $this->apiUrl . $request,
+                $this->getAbsoluteUrl($request),
                 $this->generateParameters($parameters),
                 'DELETE'
             );
@@ -359,10 +358,29 @@
 
             $parts = explode(':', $headerLine);
             $key   = array_shift($parts);
-            $value = implode(":", $parts);
+            $value = implode(':', $parts);
 
             $this->responseHeaders[$key] = trim($value);
 
             return $size;
+        }
+
+        /**
+         * Checks the given request string and returns the absolute URL to make
+         * the necessary API call
+         *
+         * @param string $request
+         *
+         * @return string
+         */
+        protected function getAbsoluteUrl($request)
+        {
+            $request = ltrim($request);
+
+            if (strpos($request, 'http') === 0) {
+                return $request;
+            }
+
+            return $this->apiUrl . $request;
         }
     }


### PR DESCRIPTION
@mjaschen I think this is what @Geovanek was alluding to in #25 

New feature in API is documented [here](http://strava.github.io/api/partner/v3/events/).  They've made a new endpoint, but it sits at a different subdomain, which makes the client inflexible for absolute URL changes.

Example (contrived) usage:
```php
$webhookResponse = $stravaApi->post('https://api.strava.com/api/v3/push_subscriptions', []);
```