### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Delete an activity *[2]*
 $api->delete('activities/:id');
 ```
 
-###Notes
+### Notes
 
 **1**. The account you register your app will give you an access token, so you can skip this step if you're just testing endpoints/methods.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
