### PR TITLE
CURLOPT_SSL_VERIFYPEER on StravaApi.php:129 is now set to (bool)true.

### DIFF
--- a/src/Iamstuartwilson/StravaApi.php
+++ b/src/Iamstuartwilson/StravaApi.php
@@ -126,7 +126,7 @@
             $curl = curl_init($url);
 
             $curlOptions = array(
-                CURLOPT_SSL_VERIFYPEER => false,
+                CURLOPT_SSL_VERIFYPEER => true,
                 CURLOPT_REFERER        => $url,
                 CURLOPT_RETURNTRANSFER => true,
                 CURLOPT_HEADERFUNCTION => array($this, 'parseHeader'),


### PR DESCRIPTION
`CURLOPT_SSL_VERIFYPEER` shouldn't be set to false as this possibly weakens security.<sup>1 2</sup>

I don't see any reason not to change this. In any case it works just fine on my test server.

This option defaults to `true`, so this line could be deleted all together. I prefer this explicit declaration though.

1. [**Issue:** Enable CURLOPT_SSL_VERIFYPEER option #18 ](https://github.com/iamstuartwilson/strava/issues/18)
2. https://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYPEER.html